### PR TITLE
Fix for the encryption key bug (was breaking ByteArray keys on Android 4)

### DIFF
--- a/src/breezedb/BreezeDbInstance.as
+++ b/src/breezedb/BreezeDbInstance.as
@@ -51,7 +51,8 @@ package breezedb
 		private var _isClosing:Boolean;
 		private var _name:String;
 		private var _file:File;
-		private var _encryptionKey:String;
+        /** String or ByteArray */
+		private var _encryptionKey:* = null;
 
 		// Migrations
 		private var _migrations:*;


### PR DESCRIPTION
On Android 4.x we were getting `SQL Error 3138 “Incorrect encryption key”` when trying to open an encrypted database with a ByteArray key (rather than a String key). I couldn't replicate the problem on Android 6.x. This is the fix.

_+Apologies for the wonky indentation, it looks fine in my IDE. Not sure how to prevent it._